### PR TITLE
Necessary fixes to make mitm-adblock work with mitmproxy version 5.1.1 + code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Use this to block ads on your mobile device, or just monitor its traffic.
  2. Install required python modules:
 
 ```
-$ pip install adblockparser Cython git+https://github.com/andreasvc/pyre2.git
+$ pip install 'Cython>=0.29.19,<1.0'  # for pyre2
+$ pip install -r requirements.txt
 ```
 
  3. Run `./update-blocklists` to download some blocklists

--- a/adblock.py
+++ b/adblock.py
@@ -7,7 +7,7 @@ An mitmproxy adblock script!
 
 import re2
 from mitmproxy.script import concurrent
-from mitmproxy.http import HTTPResponse
+from mitmproxy import http
 from adblockparser import AdblockRules
 from glob import glob
 
@@ -62,8 +62,6 @@ def request(flow):
     global rules
 
     req = flow.request
-    # accept = flow.request.headers["Accept"]
-    # log("accept: %s" % flow.request.accept)
 
     options = {'domain': req.host}
 
@@ -80,77 +78,10 @@ def request(flow):
         log("blocked-url: %s" % flow.request.url)
         log("^^^^^^^^^^^^^^^^^^^^ BLOCKED ^^^^^^^^^^^^^^^^^^^^^^^^^^^")
 
-        # resp = HTTPResponse((1,1), 404, "OK",
-        #     ODictCaseless([["Content-Type", "text/html"]]),
-        #     "A terrible ad has been removed!")
-
-        # HTTPResponse(http_version, status_code, reason, headers, content, timestamp_start=None, timestamp_end=None)
-
-        # resp = HTTPResponse(
-        #     (1,1),
-        #     200,
-        #     "OK",
-        #     ODictCaseless(
-        #         [
-        #             ["Content-Type", "text/html"]
-        #         ]
-        #     ),
-        #     "BLOCKED."
-        # )
-
-        resp = HTTPResponse(
-            (1,1),
+        flow.response = http.HTTPResponse.make(
             200,
-            "OK",
-            Headers(content_type="text/html"),
-            "BLOCKED."
+            b"BLOCKED.",
+            {"Content-Type": "text/html"}
         )
-
-        flow.reply(resp)
     else:
         log("url: %s" % flow.request.url)
-
-
-"""
-An HTTP request.
-
-Exposes the following attributes:
-
-    method: HTTP method
-
-    scheme: URL scheme (http/https)
-
-    host: Target hostname of the request. This is not neccessarily the
-    directy upstream server (which could be another proxy), but it's always
-    the target server we want to reach at the end. This attribute is either
-    inferred from the request itself (absolute-form, authority-form) or from
-    the connection metadata (e.g. the host in reverse proxy mode).
-
-    port: Destination port
-
-    path: Path portion of the URL (not present in authority-form)
-
-    httpversion: HTTP version tuple, e.g. (1,1)
-
-    headers: ODictCaseless object
-
-    content: Content of the request, None, or CONTENT_MISSING if there
-    is content associated, but not present. CONTENT_MISSING evaluates
-    to False to make checking for the presence of content natural.
-
-    form_in: The request form which mitmproxy has received. The following
-    values are possible:
-
-         - relative (GET /index.html, OPTIONS *) (covers origin form and
-           asterisk form)
-         - absolute (GET http://example.com:80/index.html)
-         - authority-form (CONNECT example.com:443)
-         Details: http://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-25#section-5.3
-
-    form_out: The request form which mitmproxy will send out to the
-    destination
-
-    timestamp_start: Timestamp indicating when request transmission started
-
-    timestamp_end: Timestamp indicating when request transmission ended
-"""

--- a/adblock.py
+++ b/adblock.py
@@ -11,6 +11,8 @@ from mitmproxy import http
 from adblockparser import AdblockRules
 from glob import glob
 
+__version__ = '0.1.0'
+
 IMAGE_MATCHER      = re2.compile(r"\.(png|jpe?g|gif)$")
 SCRIPT_MATCHER     = re2.compile(r"\.(js)$")
 STYLESHEET_MATCHER = re2.compile(r"\.(css)$")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+mitmproxy==5.1.1
+adblockparser==0.7
+git+https://github.com/andreasvc/pyre2.git

--- a/update-blocklists
+++ b/update-blocklists
@@ -9,7 +9,7 @@ cd $LISTDIR
 
 echo "* Updating blocklists in $LISTDIR"
 
-wget -N https://easylist-downloads.adblockplus.org/easylist.txt
-wget -N https://easylist-downloads.adblockplus.org/easyprivacy.txt
-wget -N https://easylist-downloads.adblockplus.org/fanboy-annoyance.txt
-wget -N https://easylist-downloads.adblockplus.org/fanboy-social.txt
+wget --no-check-certificate -N https://easylist-downloads.adblockplus.org/easylist.txt
+wget --no-check-certificate -N https://easylist-downloads.adblockplus.org/easyprivacy.txt
+wget --no-check-certificate -N https://easylist-downloads.adblockplus.org/fanboy-annoyance.txt
+wget --no-check-certificate -N https://easylist-downloads.adblockplus.org/fanboy-social.txt


### PR DESCRIPTION
* fixed imports and the code responsible for blocking requests
* added `requirements.txt` file
* cleaned up the code
* added `--no-check-certificate` for blocklists, because the certificate seems to have expired
* fixed README